### PR TITLE
Added broken namespace field for Kubernetes Deployment Target

### DIFF
--- a/octopusdeploy/resource_machine.go
+++ b/octopusdeploy/resource_machine.go
@@ -263,6 +263,7 @@ func buildMachineResource(d *schema.ResourceData) *octopusdeploy.Machine {
 		ProxyID:             proxyid,
 		ClusterCertificate:  tfSchemaList["clustercertificate"].(string),
 		ClusterURL:          tfSchemaList["clusterurl"].(string),
+		Namespace:           tfSchemaList["namespace"].(string),
 		SkipTLSVerification: strconv.FormatBool(tfSchemaList["skiptlsverification"].(bool)),
 		DefaultWorkerPoolID: tfSchemaList["defaultworkerpoolid"].(string),
 	}


### PR DESCRIPTION
Adds support for kubernetes namespaces - see https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/55